### PR TITLE
intf: add support for RTT interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Compatible with Python 3.10+.
 * Client-based triggering (global and per-channel triggers)
 * Save data to CSV files
 * Print samples
+* Stream data over UDP (compatible with [PlotJuggler](https://github.com/facontidavide/PlotJuggler))
+* NxScope protocol via serial port or Segger RTT interface
 
 ## Features Planned
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -54,6 +54,8 @@ Supported interface commands:
 
 * ``serial`` - select serial port NxScope interface
 
+* ``rtt`` - select Segger RTT as NxScope interface
+
 Configuratio commands
 =====================
 
@@ -82,5 +84,6 @@ Plugins supported so far:
 * ``pdevinfo`` - show information about the connected NxScope device
 * ``pnone`` - capture data and do nothing with them
 * ``pprinter`` - capture data and print samples
+* ``pudp`` - stream data over UDP
 
 For more information, use the plugin's ``--help`` option.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-         "nxslib>=0.9.0",
+         "nxslib>=0.9.1",
          "click>=8.1"
 ]
 classifiers = [

--- a/src/nxscli/commands/interface/cmd_rtt.py
+++ b/src/nxscli/commands/interface/cmd_rtt.py
@@ -1,0 +1,51 @@
+"""Module containint the RTT interface command for CLI."""
+
+import click
+from nxslib.intf.rtt import RTTDevice
+from nxslib.nxscope import NxscopeHandler
+
+from nxscli.cli.environment import Environment, pass_environment
+
+###############################################################################
+# Command: cmd_rtt
+###############################################################################
+
+
+@click.group(name="rtt", chain=True)
+@click.argument("target", type=str, required=True)
+@click.argument("index", type=int, required=True)
+@click.argument("bufsize", type=int, required=True)
+@click.option(
+    "--jintf", type=str, default="swd", help="JLink interface: `swd` or `jtag`"
+)
+@click.option(
+    "--blockaddr",
+    type=str,
+    default="auto",
+    help="RTT block address as hex or `auto`. Can be found with J-Link tools.",
+)
+@pass_environment
+def cmd_rtt(
+    ctx: Environment,
+    target: str,
+    index: int,
+    bufsize: int,
+    jintf: str,
+    blockaddr: str,
+) -> bool:  # pragma: no cover
+    """[interface] Connect with a RTT interface to the NxScope devie.
+
+    \b
+    target - JLINK target device string. Can be found with J-Link tools.
+    index - RTT buffer index
+    bufsize - RTT UP buffer size
+    """  # noqa: D301
+    intf = RTTDevice(target, index, bufsize, jintf, blockaddr)
+
+    # initialize nxslib communication handler
+    assert ctx.parser
+    ctx.nxscope = NxscopeHandler(intf, ctx.parser)
+
+    ctx.interface = True
+
+    return True

--- a/src/nxscli/ext_interfaces.py
+++ b/src/nxscli/ext_interfaces.py
@@ -3,9 +3,10 @@
 from typing import TYPE_CHECKING
 
 from nxscli.commands.interface.cmd_dummy import cmd_dummy
+from nxscli.commands.interface.cmd_rtt import cmd_rtt
 from nxscli.commands.interface.cmd_serial import cmd_serial
 
 if TYPE_CHECKING:
     import click
 
-interfaces_list: list["click.Group"] = [cmd_serial, cmd_dummy]
+interfaces_list: list["click.Group"] = [cmd_serial, cmd_rtt, cmd_dummy]


### PR DESCRIPTION
Test command:
`nxscli rtt nRF52832_xxAA 1 2048 chan 1 pani2 2000`

Requires https://github.com/railab/nxslib/commit/59a3691c97758dd0c23ce0a3fe9a9428687bf31b
